### PR TITLE
Sekelton Fix for Node Module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ helm/**/*.lock
 *.tgz
 .vscode
 .env
+.idea

--- a/app/graphql/resolvers/person.js
+++ b/app/graphql/resolvers/person.js
@@ -2,6 +2,6 @@ import { personHandler } from '../../core/person/person.js'
 
 export default {
   Query: {
-    person: personHandler
+    Person: personHandler
   }
 }

--- a/app/graphql/server.js
+++ b/app/graphql/server.js
@@ -1,26 +1,25 @@
 import { dirname, join } from 'path'
-import { pathToFileURL, fileURLToPath } from 'url'
+import { fileURLToPath } from 'url'
 
 import { loadFiles } from '@graphql-tools/load-files'
 import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+export const typeDefs = (async () => await loadFiles(join(__dirname, 'types'), {
+  recursive: true
+}))()
+
+export const resolvers = (async () => await loadFiles(join(__dirname, 'resolvers'), {
+  recursive: true
+}))()
+
 export async function NewApolloServer() {
-  const __dirname = dirname(fileURLToPath(import.meta.url))
-
-  const typeDefs = await loadFiles(join(__dirname, 'types'), {
-    recursive: true
-  })
-
-  const resolvers = await loadFiles(join(__dirname, 'resolvers'), {
-    recursive: true,
-    requireMethod: async path => import(pathToFileURL(path))
-  })
-
   return new ApolloServer({
-    typeDefs,
-    resolvers,
+    typeDefs: await typeDefs,
+    resolvers: await resolvers,
     plugins: [
       (() => {
         if (process.env?.NODE_ENV === 'production') {

--- a/app/graphql/server.js
+++ b/app/graphql/server.js
@@ -2,32 +2,27 @@ import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
 
 import { loadFiles } from '@graphql-tools/load-files'
+import { makeExecutableSchema } from '@graphql-tools/schema'
 import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const graphqlPath = dirname(fileURLToPath(import.meta.url))
 
-export const typeDefs = (async () => await loadFiles(join(__dirname, 'types'), {
-  recursive: true
-}))()
+export const schema = makeExecutableSchema({
+  typeDefs: await loadFiles(join(graphqlPath, 'types')),
+  resolvers: await loadFiles(join(graphqlPath, 'resolvers'))
+})
 
-export const resolvers = (async () => await loadFiles(join(__dirname, 'resolvers'), {
-  recursive: true
-}))()
+export const apolloServer = new ApolloServer({
+  schema,
+  plugins: [
+    (() => {
+      if (process.env?.NODE_ENV === 'production') {
+        return ApolloServerPluginLandingPageDisabled()
+      }
 
-export async function NewApolloServer() {
-  return new ApolloServer({
-    typeDefs: await typeDefs,
-    resolvers: await resolvers,
-    plugins: [
-      (() => {
-        if (process.env?.NODE_ENV === 'production') {
-          return ApolloServerPluginLandingPageDisabled()
-        }
-
-        return ApolloServerPluginLandingPageLocalDefault()
-      })()
-    ]
-  })
-}
+      return ApolloServerPluginLandingPageLocalDefault()
+    })()
+  ]
+})

--- a/app/graphql/server.js
+++ b/app/graphql/server.js
@@ -1,0 +1,34 @@
+import { dirname, join } from 'path'
+import { pathToFileURL, fileURLToPath } from 'url'
+
+import { loadFiles } from '@graphql-tools/load-files'
+import { ApolloServer } from '@apollo/server'
+import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
+
+export async function NewApolloServer() {
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+
+  const typeDefs = await loadFiles(join(__dirname, 'types'), {
+    recursive: true
+  })
+
+  const resolvers = await loadFiles(join(__dirname, 'resolvers'), {
+    recursive: true,
+    requireMethod: async path => import(pathToFileURL(path))
+  })
+
+  return new ApolloServer({
+    typeDefs,
+    resolvers,
+    plugins: [
+      (() => {
+        if (process.env?.NODE_ENV === 'production') {
+          return ApolloServerPluginLandingPageDisabled()
+        }
+
+        return ApolloServerPluginLandingPageLocalDefault()
+      })()
+    ]
+  })
+}

--- a/app/graphql/types/person.gql
+++ b/app/graphql/types/person.gql
@@ -4,5 +4,5 @@ type Person {
 }
 
 extend type Query {
-    Person(personId: Int!): Person!
+    Person(personId: ID!): Person!
 }

--- a/app/index.js
+++ b/app/index.js
@@ -1,8 +1,11 @@
 import hapiApollo from '@as-integrations/hapi'
 
-import { apolloServer, server } from './server.js'
+import { server } from './server.js'
+import { NewApolloServer } from './graphql/server.js'
 
 const init = async () => {
+  const apolloServer = await NewApolloServer()
+
   await apolloServer.start()
   await server.register({
     plugin: hapiApollo.default,

--- a/app/index.js
+++ b/app/index.js
@@ -1,11 +1,9 @@
 import hapiApollo from '@as-integrations/hapi'
 
 import { server } from './server.js'
-import { NewApolloServer } from './graphql/server.js'
+import { apolloServer } from './graphql/server.js'
 
 const init = async () => {
-  const apolloServer = await NewApolloServer()
-
   await apolloServer.start()
   await server.register({
     plugin: hapiApollo.default,

--- a/app/server.js
+++ b/app/server.js
@@ -20,7 +20,6 @@ const typeDefs = loadFilesSync(join(__dirname, 'graphql', 'types'), {
 
 const resolvers = loadFilesSync(join(__dirname, 'graphql', 'resolvers'), {
   recursive: true,
-  requireMethod: async path => import(pathToFileURL(path))
 })
 
 export const apolloServer = new ApolloServer({

--- a/app/server.js
+++ b/app/server.js
@@ -1,9 +1,3 @@
-import { ApolloServer } from '@apollo/server'
-import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
-import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
-import { dirname, join } from 'path'
-import { loadFilesSync } from '@graphql-tools/load-files'
-import { pathToFileURL, fileURLToPath } from 'url'
 import hapi from '@hapi/hapi'
 
 import { healthyRoute } from './routes/healthy.js'
@@ -11,30 +5,6 @@ import { healthzRoute } from './routes/healthz.js'
 import { setupAppInsights } from './insights.js'
 
 setupAppInsights()
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-const typeDefs = loadFilesSync(join(__dirname, 'graphql', 'types'), {
-  recursive: true
-})
-
-const resolvers = loadFilesSync(join(__dirname, 'graphql', 'resolvers'), {
-  recursive: true,
-})
-
-export const apolloServer = new ApolloServer({
-  typeDefs,
-  resolvers,
-  plugins: [
-    (() => {
-      if (process.env?.NODE_ENV === 'production') {
-        return ApolloServerPluginLandingPageDisabled()
-      }
-
-      return ApolloServerPluginLandingPageLocalDefault()
-    })()
-  ]
-})
 
 export const server = hapi.server({
   port: process.env.PORT

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@apollo/server": "4.9.4",
         "@as-integrations/hapi": "2.0.1",
         "@graphql-tools/load-files": "7.0.0",
+        "@graphql-tools/schema": "^10.0.0",
         "@hapi/hapi": "21.3.2",
         "applicationinsights": "2.8.0",
         "graphql": "16.8.1"
@@ -128,6 +129,44 @@
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/merge": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "dependencies": {
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/schema": {
+      "version": "9.0.19",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "dependencies": {
+        "@graphql-tools/merge": "^8.4.1",
+        "@graphql-tools/utils": "^9.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@apollo/server/node_modules/lru-cache": {
@@ -1178,38 +1217,48 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
       "dependencies": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
       "dependencies": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.7.tgz",
+      "integrity": "sha512-KOdeMj6Hd/MENDaqPbws3YJl3wVy0DeYnL7PyUms5Skyf7uzI9INynDwPMhLXfSb0/ph6BXTwMd5zBtWbF8tBQ==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "dset": "^3.1.2",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -3405,6 +3454,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ee-first": {
@@ -8594,6 +8651,35 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
+        "@graphql-tools/merge": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+          "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+          "requires": {
+            "@graphql-tools/utils": "^9.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@graphql-tools/schema": {
+          "version": "9.0.19",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
+          "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+          "requires": {
+            "@graphql-tools/merge": "^8.4.1",
+            "@graphql-tools/utils": "^9.2.1",
+            "tslib": "^2.4.0",
+            "value-or-promise": "^1.0.12"
+          }
+        },
+        "@graphql-tools/utils": {
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+          "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.1.1",
+            "tslib": "^2.4.0"
+          }
+        },
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -9375,31 +9461,32 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
-      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
+      "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
       "requires": {
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0"
       }
     },
     "@graphql-tools/schema": {
-      "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
-      "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
+      "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
       "requires": {
-        "@graphql-tools/merge": "^8.4.1",
-        "@graphql-tools/utils": "^9.2.1",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/utils": "^10.0.0",
         "tslib": "^2.4.0",
         "value-or-promise": "^1.0.12"
       }
     },
     "@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.7.tgz",
+      "integrity": "sha512-KOdeMj6Hd/MENDaqPbws3YJl3wVy0DeYnL7PyUms5Skyf7uzI9INynDwPMhLXfSb0/ph6BXTwMd5zBtWbF8tBQ==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "dset": "^3.1.2",
         "tslib": "^2.4.0"
       }
     },
@@ -11150,6 +11237,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q=="
     },
     "ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:watch": "jest --coverage=false --onlyChanged --watch --runInBand",
     "test:lint": "standard",
     "test:debug": "node --inspect-brk=0.0.0.0 ./node_modules/jest/bin/jest.js --coverage=false --onlyChanged --watch --runInBand --no-cache",
-    "start:dev": "nodemon --ext js app/index.js",
+    "start:dev": "nodemon --ext js,gql app/index.js",
     "start:watch": "nodemon --inspect=0.0.0.0 --ext js --legacy-watch app/index.js",
     "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext js --legacy-watch app/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@apollo/server": "4.9.4",
     "@as-integrations/hapi": "2.0.1",
     "@graphql-tools/load-files": "7.0.0",
+    "@graphql-tools/schema": "^10.0.0",
     "@hapi/hapi": "21.3.2",
     "applicationinsights": "2.8.0",
     "graphql": "16.8.1"


### PR DESCRIPTION
 * Resolves the race issue for loading GraphQL Types & Resolvers
 * Code for Apollo Server located within bounded context of `GraphQL` package
 * Resolvers and Type definitions are exported to be used in unit tests